### PR TITLE
Update linear_regression.ipynb, bias correction

### DIFF
--- a/src/MLC/notebooks/linear_regression.ipynb
+++ b/src/MLC/notebooks/linear_regression.ipynb
@@ -142,7 +142,8 @@
     "\n",
     "    def predict(self, X):\n",
     "        n = X.shape[0]\n",
-    "        X = np.hstack([X, np.ones((n, 1))])\n",
+# while predicting as well the bias must be prepended
+    "        X = np.hstack([np.ones((n, 1)), X])\n",
     "        return X @ self.W\n",
     "    \n"
    ]


### PR DESCRIPTION
While predicting as well we should prepend the 1s array, there will be mutiplication mismatch. 